### PR TITLE
Trigger syntax checking action to run on pull request

### DIFF
--- a/.github/workflows/check-for-syntax-errors.yml
+++ b/.github/workflows/check-for-syntax-errors.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 name: Check for syntax errors
 jobs:
   check-for-syntax-errors:


### PR DESCRIPTION
The syntax checking action should now run on both `push` and `pull_request`.